### PR TITLE
Xcrum 95

### DIFF
--- a/src/OurTime.WebUI/OurTime.WebUI.csproj
+++ b/src/OurTime.WebUI/OurTime.WebUI.csproj
@@ -28,5 +28,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/src/OurTime.WebUI/appsettings.json
+++ b/src/OurTime.WebUI/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=tcp:YOUR_AZURE_SQL_SERVER.database.windows.net,1433;Initial Catalog=YOUR_DATABASE_NAME;User ID=YOUR_USERNAME;Password=YOUR_PASSWORD;Encrypt=True;"
+    "DefaultConnection": "Server=tcp:otwatches.database.windows.net,1433;Initial Catalog=WatchCatalogDB;User ID=azureadmin;Password=OTwatches1;Encrypt=True;",
+    "StaticWatchConnection": "Server=tcp:otwatches.database.windows.net,1433;Initial Catalog=WatchCatalogDB;Persist Security Info=False;User ID=azureadmin;Password=Otwatches1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
   },
   "ExternalApis": {
     "ReviewEngine": "", 


### PR DESCRIPTION
### Vad som har ändrats
- Lade till läsning från tabellen `StaticWatches` i databasen (visas på Home/Index)
- Behöll alla 6 hårdkodade klockor
- Visar nu även kommande klockor från databasen UTAN påverkan på EF. Detta är helt separat. 

### Viktigt
Jag lade till NuGet-paketet `System.Data.SqlClient` för att använda ADO.NET (`SqlConnection` och `SqlCommand`).

👉 Ni behöver inte installera det själva – Visual Studio laddar ner det automatiskt om ni kör `dotnet restore` eller bara öppnar projektet.

✅ `StaticWatchConnection` finns i `appsettings.json`. Kontrollera att ni har rätt connection string eller mockdata om ni jobbar lokalt utan Azure.

---

Säg till om något ser konstigt ut eller om swiper/layout behöver justeras för de nya klockorna!
